### PR TITLE
Add netlify build hook

### DIFF
--- a/netlify.sh
+++ b/netlify.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# blogc runner for Netlify.
+#
+# Copyright (C) 2018 Rafael G. Martins <rafael@rafaelmartins.eng.br>
+#
+# This program can be distributed under the terms of the BSD License.
+# See https://github.com/blogc/blogc/blob/master/LICENSE for details.
+#
+
+set -ex
+
+I() {
+    if [[ -z "${BLOGC_VERSION}" ]]; then
+        BLOGC_VERSION=$(wget -qO- https://blogc.rgm.io/ | grep '^LATEST_RELEASE=' | cut -d= -f2)
+    fi
+
+    local P="blogc-static-amd64-${BLOGC_VERSION}"
+    local BASE_URL="https://distfiles.rgm.io/blogc/blogc-${BLOGC_VERSION}"
+
+    if ! wget -q "${BASE_URL}/${P}.xz"{,.sha512}; then
+        echo "Failed to fetch blogc binary. Please check BLOGC_VERSION"
+        exit 1
+    fi
+
+    sha512sum -c "${P}.xz.sha512"
+
+    xz -cd "${P}.xz" > blogc
+    chmod +x blogc
+
+    ./blogc -m -f blogcfile all
+}
+
+I

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+publish = "_build"
+command = "bash netlify.sh"
+
+[template.environment]
+BLOGC_VERSION = "Set BLOGC_VERSION here. If not set, latest release will be used"


### PR DESCRIPTION
## 概要

Netlify でビルドするための設定を追加．

https://github.com/blogc/blogc-netlify のコピー．

## 備考

- ビルドフックが起動することの確認
- https://tarotene.dev でアクセスできることの確認

などの検証系は事後的に行う．